### PR TITLE
Make getobs(::Dict) type-inferred

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLCore"
 uuid = "c2834f40-e789-41da-a90e-33b280584a8c"
 authors = ["Carlo Lucibello <carlo.lucibello@gmail.com> and contributors"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/observation.jl
+++ b/src/observation.jl
@@ -226,9 +226,19 @@ end
 
 numobs(data::Dict) = _check_numobs(data)
 
-getobs(data::Dict, i) = Dict(k => getobs(v, i) for (k, v) in pairs(data))
+# The value type `V2` is computed explicitly so that the returned `Dict` is
+# type-stable. A plain `Dict(generator)` comprehension infers poorly when the
+# observations have heterogeneous types (e.g. `Dict{String, Array}`), returning
+# `Union{Dict{Any,Any}, Dict{String}}` instead of `Dict{String, Any}`.
+function getobs(data::Dict{K,V}, i) where {K,V}
+    V2 = Base.promote_op(getobs, V, typeof(i))
+    return Dict{K,V2}(k => getobs(v, i) for (k, v) in pairs(data))
+end
 
-getobs(data::Dict) = Dict(k => getobs(v) for (k, v) in pairs(data))
+function getobs(data::Dict{K,V}) where {K,V}
+    V2 = Base.promote_op(getobs, V)
+    return Dict{K,V2}(k => getobs(v) for (k, v) in pairs(data))
+end
 
 function getobs!(buffers, data::Dict, i)
     for (k, v) in pairs(data)

--- a/test/observation.jl
+++ b/test/observation.jl
@@ -61,14 +61,17 @@ end
     dataset = Dict("X" => X, "y" => y) 
     @test numobs(dataset) == 15
 
-    @test_broken @inferred getobs(dataset, 2) # not inferred
-    o = getobs(dataset, 2)
+    o = @inferred getobs(dataset, 2)
     @test o["X"] == X[:,2]
     @test o["y"] == y[2]
 
-    o = getobs(dataset, 1:2)
+    o = @inferred getobs(dataset, 1:2)
     @test o["X"] == X[:,1:2]
     @test o["y"] == y[1:2]
+
+    # a homogeneous dict keeps a precise (non-`Any`) value type
+    hdata = Dict(:a => rand(2, 3), :b => rand(2, 3))
+    @test @inferred(getobs(hdata, 2)) isa Dict{Symbol, Vector{Float64}}
 end
 
 @testset "numobs" begin


### PR DESCRIPTION
## What

`getobs(data::Dict, i)` and `getobs(data::Dict)` were not type-inferred for heterogeneous dictionaries.

For a dict like `Dict("X" => rand(4,15), "y" => string_vector)` (type `Dict{String, Array}`), the `Dict(generator)` comprehension inferred the return type as `Union{Dict{Any,Any}, Dict{String}}` instead of `Dict{String, Any}`, so `@inferred getobs(dataset, 2)` failed. This was tracked as a `@test_broken` here and in [MLUtils#227](https://github.com/JuliaML/MLUtils.jl/issues/227).

## Fix

Compute the value type explicitly via `Base.promote_op` and construct a fully-typed `Dict{K,V2}`:

```julia
function getobs(data::Dict{K,V}, i) where {K,V}
    V2 = Base.promote_op(getobs, V, typeof(i))
    return Dict{K,V2}(k => getobs(v, i) for (k, v) in pairs(data))
end
```

The same treatment is applied to the no-index `getobs(data::Dict)`.

This makes both methods inferrable for heterogeneous dicts (→ `Dict{String, Any}`) while **preserving the precise value type for homogeneous ones** (e.g. `Dict{Symbol, Vector{Float64}}`). It also fixes the empty-dict edge case (the old comprehension returned `Dict{Any,Any}` for an empty input).

## Tests

- Flipped the previously `@test_broken` inference test in the `"dict"` testset to `@inferred`.
- Added an assertion that a homogeneous dict keeps a precise (non-`Any`) value type.
- Full suite passes locally (191/191).

Patch version bumped to `1.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)