### PR TITLE
Revert getobs(::Dict) to comprehension, preferring narrow value types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLCore"
 uuid = "c2834f40-e789-41da-a90e-33b280584a8c"
 authors = ["Carlo Lucibello <carlo.lucibello@gmail.com> and contributors"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/observation.jl
+++ b/src/observation.jl
@@ -226,19 +226,20 @@ end
 
 numobs(data::Dict) = _check_numobs(data)
 
-# The value type `V2` is computed explicitly so that the returned `Dict` is
-# type-stable. A plain `Dict(generator)` comprehension infers poorly when the
-# observations have heterogeneous types (e.g. `Dict{String, Array}`), returning
-# `Union{Dict{Any,Any}, Dict{String}}` instead of `Dict{String, Any}`.
-function getobs(data::Dict{K,V}, i) where {K,V}
-    V2 = Base.promote_op(getobs, V, typeof(i))
-    return Dict{K,V2}(k => getobs(v, i) for (k, v) in pairs(data))
-end
+# We build the result with a `Dict(generator)` comprehension, which keeps the
+# value type as narrow as the actual observations: a homogeneous dict like
+# `Dict{Symbol, Matrix{Float64}}` stays precise (and inferrable), and a batch of
+# a heterogeneous-but-abstract dict like `Dict{String, Array{Float64}}` is kept
+# at `Dict{String, Array{Float64}}` rather than widened to `Dict{String, Any}`.
+#
+# For a genuinely heterogeneous dict the comprehension is not type-stable (it
+# infers as `Union{Dict{Any,Any}, Dict{String}}`), but that is unavoidable: a
+# stable result would have to widen the value type all the way to `Any` — which
+# loses the narrow type without buying any usable static information, since the
+# values are `Any` either way. We prefer the narrow type.
+getobs(data::Dict, i) = Dict(k => getobs(v, i) for (k, v) in pairs(data))
 
-function getobs(data::Dict{K,V}) where {K,V}
-    V2 = Base.promote_op(getobs, V)
-    return Dict{K,V2}(k => getobs(v) for (k, v) in pairs(data))
-end
+getobs(data::Dict) = Dict(k => getobs(v) for (k, v) in pairs(data))
 
 function getobs!(buffers, data::Dict, i)
     for (k, v) in pairs(data)

--- a/test/observation.jl
+++ b/test/observation.jl
@@ -58,20 +58,28 @@ end
 end
 
 @testset "dict" begin
-    dataset = Dict("X" => X, "y" => y) 
+    dataset = Dict("X" => X, "y" => y)
     @test numobs(dataset) == 15
 
-    o = @inferred getobs(dataset, 2)
+    @test_broken @inferred getobs(dataset, 2) # not inferred for heterogeneous dicts
+    o = getobs(dataset, 2)
     @test o["X"] == X[:,2]
     @test o["y"] == y[2]
 
-    o = @inferred getobs(dataset, 1:2)
+    o = getobs(dataset, 1:2)
     @test o["X"] == X[:,1:2]
     @test o["y"] == y[1:2]
 
-    # a homogeneous dict keeps a precise (non-`Any`) value type
+    # a homogeneous dict keeps a precise (non-`Any`) value type, inferrably
     hdata = Dict(:a => rand(2, 3), :b => rand(2, 3))
     @test @inferred(getobs(hdata, 2)) isa Dict{Symbol, Vector{Float64}}
+
+    # the value type is kept as narrow as the observations rather than widened
+    # to `Any`: batching a heterogeneous-but-abstract dict keeps the value type
+    adata = Dict("x" => rand(2, 4), "y" => rand(4))  # Dict{String, Array{Float64}}
+    @test adata isa Dict{String, Array{Float64}}
+    @test getobs(adata, 1:2) isa Dict{String, Array{Float64}}
+    @test getobs(adata) isa Dict{String, Array{Float64}}
 end
 
 @testset "numobs" begin


### PR DESCRIPTION
## What

Reverts the `getobs(::Dict)` change from #4 (computing the value type via `Base.promote_op`) back to the `Dict(generator)` comprehension, and bumps to `1.0.2`.

## Why

#4 made `getobs(::Dict)` type-stable by constructing a fully-typed `Dict{K,V2}` with `V2 = Base.promote_op(getobs, V, typeof(i))`. For a **heterogeneous-but-abstract** dict — e.g. `Dict{String, Array{Float64}}`, where the value type is abstract because `ndims` is unknown — `promote_op` cannot narrow the per-value `getobs` result below `Any`, so the whole result is widened to `Dict{String, Any}`.

That widening is a regression:

- The narrow value type (`Array{Float64}`) is genuinely useful downstream; the "stable" `Dict{String, Any}` carries **no usable static information** (the values are `Any` either way).
- It broke [MLUtils' DataLoader test](https://github.com/JuliaML/MLUtils.jl/blob/main/test/dataloader.jl), which relies on batches of such dicts keeping `Dict{String, Array{Float64}}`.

The comprehension keeps the value type as narrow as the actual observations, and is **already type-stable and precise** for the common homogeneous/concrete case (e.g. `Dict{Symbol, Matrix{Float64}}` — verified by the retained test). It is only type-unstable for *genuinely* heterogeneous dicts, where the only stable alternative is the unhelpful `Dict{String, Any}` — so there's nothing real to gain there.

| case | this PR (comprehension) | #4 |
|---|---|---|
| homogeneous `Dict{Symbol,Matrix{Float64}}` | narrow + **stable** | narrow + stable |
| batched `Dict{String,Array{Float64}}` | **narrow** `Array{Float64}` | wide `Any` |
| genuinely heterogeneous `Dict{String,Any}` | narrow, unstable (2-way union) | `Any`, stable |

This effectively restores the v1.0.0 behavior.

## Tests

- `@inferred getobs(heterogeneous_dict, i)` returns to `@test_broken` — requiring inference of an inherently dynamic container was the wrong ask.
- **New test** asserting the narrow value type is preserved: `getobs(::Dict{String,Array{Float64}}, 1:2) isa Dict{String, Array{Float64}}` (and the no-index form).
- The homogeneous-dict precision test from #4 is retained (still passes).
- Full suite: 194 pass, 1 broken (the intended `@test_broken`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)